### PR TITLE
aiven oauthbearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,31 @@ npx superstream-kafka-analyzer --config config.json
 }
 ```
 
+```json
+{
+  "kafka": {
+    "bootstrap_servers": ["your-aiven-cluster.aivencloud.com:12345"],
+    "clientId": "superstream-analyzer",
+    "vendor": "aiven",
+    "useSasl": true,
+    "sasl": {
+      "mechanism": "oauthbearer",
+      "clientId": "your-client-id",
+      "clientSecret": "your-client-secret",
+      "host": "https://my-oauth-server.com",
+      "path": "/oauth/token",
+    }
+  },
+  "file": {
+    "outputDir": "./kafka-analysis",
+    "formats": ["html"],
+    "includeMetadata": true,
+    "includeTimestamp": true
+  },
+  "email": "user@example.com"
+}
+```
+
 ### Email Collection
 
 The tool collects your email address to generate comprehensive report files. This is optional:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "inquirer": "^8.2.4",
     "joi": "^17.11.0",
     "kafkajs": "^2.2.4",
-    "ora": "^5.4.1"
+    "ora": "^5.4.1",
+    "simple-oauth2": "^5.1.0"
   },
   "devDependencies": {
     "eslint": "^8.55.0",

--- a/src/kafka-client.js
+++ b/src/kafka-client.js
@@ -1,8 +1,9 @@
-const { Kafka } = require('kafkajs');
+const { Kafka, logLevel } = require('kafkajs');
 const fs = require('fs').promises;
 const chalk = require('chalk');
 const crypto = require('crypto');
 const { generateAuthToken } = require('aws-msk-iam-sasl-signer-js');
+const { ClientCredentials } = require('simple-oauth2');
 
 class KafkaClient {
   constructor(config) {
@@ -81,13 +82,43 @@ class KafkaClient {
             break;
 
           case 'aiven':
-            // Aiven uses SASL_SSL with SCRAM-SHA-256
+            // Only support SASL_SSL at this time
             kafkaConfig.ssl = true;
-            kafkaConfig.sasl = {
-              mechanism: 'scram-sha-256', // Aiven typically uses SCRAM-SHA-256
-              username: this.config.sasl.username,
-              password: this.config.sasl.password
-            };
+            if (mechanism === 'oauthbearer') {
+              kafkaConfig.sasl = {
+                mechanism: 'oauthbearer',
+                oauthBearerProvider: async () => {
+                  const client = new ClientCredentials({
+                    client: {
+                      id: this.config.sasl.clientId,
+                      secret: this.config.sasl.clientSecret
+                    },
+                    auth: {
+                      tokenHost: this.config.sasl.host,
+                      tokenPath: this.config.sasl.path
+                    }
+                  });
+
+                  try {
+                    console.log("Getting access token...");
+                    const accessToken = await client.getToken({});
+
+                    return {
+                      value: accessToken.token.access_token
+                    };
+
+                  } catch (error) {
+                    throw error;
+                  }
+                }
+              };
+            } else {
+              kafkaConfig.sasl = {
+                mechanism: 'scram-sha-256', // Aiven typically uses SCRAM-SHA-256
+                username: this.config.sasl.username,
+                password: this.config.sasl.password
+              };
+            }
             break;
 
           case 'confluent-platform':


### PR DESCRIPTION
Add the possibility to use `oauthbearer` mechanism for aiven vendor.
Because kafka analyzer seems to be a "one shot process", there is no refresh token process in this authentication path and we ask for a new token for each run.